### PR TITLE
Standby using WAL archives from  GCS bucket

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -280,10 +280,10 @@ spec:
               type: integer
             standby:
               type: object
-              required:
-                - s3_wal_path
               properties:
                 s3_wal_path:
+                  type: string
+                gs_wal_path:
                   type: string
             teamId:
               type: string

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -294,7 +294,11 @@ archive is supported.
 
 * **s3_wal_path**
   the url to S3 bucket containing the WAL archive of the remote primary.
-  Required when the `standby` section is present.
+  Either this or gs_wal_path is required when the `standby` section is present.
+
+* **gs_wal_path**
+  the url to GCS bucket containing the WAL archive of the remote primary.
+  Either this or s3_wal_path is required when the `standby` section is present.
 
 ## EBS volume resizing
 

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -244,10 +244,10 @@ spec:
               type: integer
             standby:
               type: object
-              required:
-                - s3_wal_path
               properties:
                 s3_wal_path:
+                  type: string
+                gs_wal_path:
                   type: string
             teamId:
               type: string

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -407,11 +407,13 @@ var PostgresCRDResourceValidation = apiextv1beta1.CustomResourceValidation{
 					},
 					"standby": {
 						Type:     "object",
-						Required: []string{"s3_wal_path"},
 						Properties: map[string]apiextv1beta1.JSONSchemaProps{
 							"s3_wal_path": {
 								Type: "string",
 							},
+							"gs_wal_path": {
+								Type: "string",
+							}
 						},
 					},
 					"teamId": {

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -123,7 +123,8 @@ type Patroni struct {
 
 //StandbyCluster
 type StandbyDescription struct {
-	S3WalPath string `json:"s3_wal_path,omitempty"`
+	S3WalPath string `json:"s3_wal_path,omitempty"`,
+	GSWalPath string `json:"gs_wal_path,omitempty"`
 }
 
 // CloneDescription describes which cluster the new should clone and up to which point in time

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -808,8 +808,8 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		sort.Slice(customPodEnvVarsList,
 			func(i, j int) bool { return customPodEnvVarsList[i].Name < customPodEnvVarsList[j].Name })
 	}
-	if spec.StandbyCluster != nil && spec.StandbyCluster.S3WalPath == "" {
-		return nil, fmt.Errorf("s3_wal_path is empty for standby cluster")
+	if spec.StandbyCluster != nil && spec.StandbyCluster.S3WalPath == "" && spec.StandbyCluster.GSWalPath == "" {
+		return nil, fmt.Errorf("s3_wal_path and s3_wal_path are empty for standby cluster")
 	}
 
 	// backward compatible check for InitContainers
@@ -1417,17 +1417,29 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescription) []v1.EnvVar {
 	result := make([]v1.EnvVar, 0)
 
-	if description.S3WalPath == "" {
+	if description.S3WalPath != "" {
+		// standby with S3, find out the bucket to setup standby
+		msg := "Standby from S3 bucket using custom parsed S3WalPath from the manifest %s "
+		c.logger.Infof(msg, description.S3WalPath)
+
+		result = append(result, v1.EnvVar{
+			Name:  "STANDBY_WALE_S3_PREFIX",
+			Value: description.S3WalPath,
+		})
+
+	} else if description.GSWalPath != "" {
+		// standby with GS, find out the bucket to setup standby
+		msg := "Standby from GS bucket using custom parsed GSWalPath from the manifest %s "
+		c.logger.Infof(msg, description.GSWalPath)
+
+		result = append(result, v1.EnvVar{
+			Name:  "STANDBY_WALE_GS_PREFIX",
+			Value: description.GSWalPath,
+		})
+
+	} else {
 		return nil
 	}
-	// standby with S3, find out the bucket to setup standby
-	msg := "Standby from S3 bucket using custom parsed S3WalPath from the manifest %s "
-	c.logger.Infof(msg, description.S3WalPath)
-
-	result = append(result, v1.EnvVar{
-		Name:  "STANDBY_WALE_S3_PREFIX",
-		Value: description.S3WalPath,
-	})
 
 	result = append(result, v1.EnvVar{Name: "STANDBY_METHOD", Value: "STANDBY_WITH_WALE"})
 	result = append(result, v1.EnvVar{Name: "STANDBY_WAL_BUCKET_SCOPE_PREFIX", Value: ""})

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -809,7 +809,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 			func(i, j int) bool { return customPodEnvVarsList[i].Name < customPodEnvVarsList[j].Name })
 	}
 	if spec.StandbyCluster != nil && spec.StandbyCluster.S3WalPath == "" && spec.StandbyCluster.GSWalPath == "" {
-		return nil, fmt.Errorf("s3_wal_path and s3_wal_path are empty for standby cluster")
+		return nil, fmt.Errorf("s3_wal_path and gs_wal_path are empty for standby cluster")
 	}
 
 	// backward compatible check for InitContainers


### PR DESCRIPTION
1. Spin up a standby cluster using WAL archives from GCP bucket
2. Either `s3_wal_path` or `gs_wal_path` are mandatory
3. Setting `gs_wal_path` will set set environment variable `STANDBY_WALE_GS_PREFIX` which will then be used by wal-g to use gcp sdk